### PR TITLE
Add a check for ExoPowershellModule.dll

### DIFF
--- a/PSCloudConnect/Public/Get-LAConnected.ps1
+++ b/PSCloudConnect/Public/Get-LAConnected.ps1
@@ -165,7 +165,13 @@ function Get-LAConnected {
             }
             else {
                 Try {
-                    Connect-EXOPSSession -UserPrincipalName $Credential.UserName -ErrorAction Stop
+		    $modules = @(Get-ChildItem -Path "$($env:LOCALAPPDATA)\Apps\2.0" -Filter "Microsoft.Exchange.Management.ExoPowershellModule.manifest" -Recurse )
+                    $moduleName =  Join-Path $modules[0].Directory.FullName "Microsoft.Exchange.Management.ExoPowershellModule.dll"
+                    Import-Module -FullyQualifiedName $moduleName -Force
+                    $scriptName =  Join-Path $modules[0].Directory.FullName "CreateExoPSSession.ps1"
+                    . $scriptName
+                    $null = Connect-EXOPSSession
+                    $exchangeOnlineSession = (Get-PSSession | Where-Object { ($_.ConfigurationName -eq 'Microsoft.Exchange') -and ($_.State -eq 'Opened') })[0]
                     Write-Output "*******************************************"
                     Write-Output "You have successfully connected to Exchange"
                     Write-Output "*******************************************"


### PR DESCRIPTION
When connecting with the -Exchange and -MFA parameters Connect-EXOPSSession fails unless you manually load the module. I was able to fix this by [https://blogs.technet.microsoft.com/canitpro/2017/08/23/powershell-basics-connecting-to-exchange-online-using-multi-factor-authentication/](pasting the snippet here) in at line 168, and then removing the redundant "Connect-EXOPSSession" line.

This allows Get-LaConnected to load the ExoPowershellModule for you instead of it complaining that the module doesn't exist when you've already installed it.